### PR TITLE
static_cast for print with PRIu64

### DIFF
--- a/include/tqdm/tqdm.h
+++ b/include/tqdm/tqdm.h
@@ -119,7 +119,9 @@ public:
 
     TQDM_IT::_incr();
     if (this->get() == e) {
-      printf("\nfinished: %" PRIu64 "/%" PRIu64 "\n", self.total, self.total);
+      printf("\nfinished: %" PRIu64 "/%" PRIu64 "\n",
+        static_cast<std::uint64_t>(self.total),
+        static_cast<std::uint64_t>(self.total));
     } else
       printf("\r%" PRIi64 " left", (int64_t)(e - this->get()));
   }


### PR DESCRIPTION
Building tests on my machine results on errors like 
```
In file included from /Users/tdegeus/data/prog/forks/tqdm.cpp/test/test-example.cpp:4:
/Users/tdegeus/data/prog/forks/tqdm.cpp/include/tqdm/tqdm.h:122:55: error: format specifies type 'unsigned long long' but the argument has
      type 'size_t' (aka 'unsigned long') [-Werror,-Wformat]
      printf("\nfinished: %" PRIu64 "/%" PRIu64 "\n", self.total, self.total);
                          ~~~~~~~~~                   ^~~~~~~~~~
/Users/tdegeus/data/prog/forks/tqdm.cpp/test/test-example.cpp:15:17: note: in instantiation of member function 'tqdm::Tqdm<int *>::_incr'
      requested here
  for (auto i = tqdm::tqdm(a, a + N); i != i.end(); ++i)
                ^
```

This should fix it