### PR TITLE
Adding CMake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,66 @@
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 2.8...3.13)
 
 project(tqdm)
+
+# Find version
+
+file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/include/tqdm/tqdm.h" tqdm_version_defines
+     REGEX "#define TQDM_VERSION_(MAJOR|MINOR|PATCH)")
+
+foreach(ver ${tqdm_version_defines})
+    if(ver MATCHES "#define TQDM_VERSION_(MAJOR|MINOR|PATCH) +([^ ]+)$")
+        set(TQDM_VERSION_${CMAKE_MATCH_1}
+            "${CMAKE_MATCH_2}"
+            CACHE INTERNAL "")
+    endif()
+endforeach()
+
+set(TQDM_VERSION ${TQDM_VERSION_MAJOR}.${TQDM_VERSION_MINOR}.${TQDM_VERSION_PATCH})
+
+message(STATUS "Building tqdm v${TQDM_VERSION}")
+
+# Set target
+
+add_library(tqdm.cpp INTERFACE)
+
+# set_target_properties(tdqm.cpp PROPERTIES OUTPUT_NAME tqdm)
+
+target_include_directories(tqdm.cpp INTERFACE
+    $<INSTALL_INTERFACE:include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+
+# Installation
+
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
+
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/" DESTINATION include)
+
+install(TARGETS tqdm.cpp EXPORT tqdm-targets)
+
+install(
+    EXPORT tqdm-targets
+    FILE tqdmTargets.cmake
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/tqdm")
+
+set(_TQDM ${CMAKE_SIZEOF_VOID_P})
+unset(CMAKE_SIZEOF_VOID_P)
+
+write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/tqdmConfigVersion.cmake"
+    VERSION ${TQDM_VERSION}
+    COMPATIBILITY AnyNewerVersion)
+
+set(CMAKE_SIZEOF_VOID_P ${_TQDM})
+
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/tqdmConfig.cmake"
+              "${CMAKE_CURRENT_BINARY_DIR}/tqdmConfigVersion.cmake"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/tqdm")
+
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/tqdm.pc.in"
+               "${CMAKE_CURRENT_BINARY_DIR}/tqdm.pc" @ONLY)
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/tqdm.pc"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/")
 
 # so we can set up visual studio "folders"
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
@@ -124,7 +184,7 @@ endif()
 
 ## target_link_libraries(tqdm)
 
-if(UNIX)
+if(UNIX AND NOT APPLE)
 
 macro(STRIP_FMT TARG STRIP_FMT_TARG STRIP_FMT_DEPS)
   if(CMAKE_COMPILER_IS_GNUCXX)
@@ -147,7 +207,7 @@ STRIP_FMT(     tqdm "$<TARGET_FILE:tqdm>"      "${TQDM_BIN_FILES}")
 STRIP_FMT(test_tqdm "$<TARGET_FILE:test_tqdm>" "${TQDM_TEST_FILES}")
 STRIP_FMT(tqdmlib   "$<TARGET_FILE:tqdmlib>"   "${TQDM_LIB_FILES}")
 
-endif(UNIX)
+endif()
 
 add_custom_command(
   TARGET test_tqdm

--- a/include/tqdm/tqdm.h
+++ b/include/tqdm/tqdm.h
@@ -36,6 +36,10 @@ Usage:
 #include <utility>      // swap
 #include "tqdm/utils.h"
 
+#define TQDM_VERSION_MAJOR 0
+#define TQDM_VERSION_MINOR 0
+#define TQDM_VERSION_PATCH 0
+
 #ifndef SIZE_T_MAX
 constexpr size_t SIZE_T_MAX = std::numeric_limits<size_t>::max();
 #endif

--- a/tqdm.pc.in
+++ b/tqdm.pc.in
@@ -1,0 +1,7 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir=${prefix}/include
+
+Name: @PROJECT_NAME@
+Description: C++ equivalent of tqdm
+Version: @TQDM_VERSION@
+Cflags: -I${includedir}

--- a/tqdmConfig.cmake
+++ b/tqdmConfig.cmake
@@ -1,0 +1,21 @@
+# tqdm cmake module
+#
+# This module sets the target:
+#
+#   tqdm.cpp
+#
+# In addition, it sets the following variables:
+#
+#   tqdm_FOUND - true if tqdm found
+#   tqdm_VERSION - tqdm's version
+#   tqdm_INCLUDE_DIRS - the directory containing tqdm headers
+#
+
+include(CMakeFindDependencyMacro)
+
+# Define target "tqdm"
+
+if(NOT TARGET tqdm.cpp)
+    include("${CMAKE_CURRENT_LIST_DIR}/tqdmTargets.cmake")
+    get_target_property(tqdm_INCLUDE_DIRS tqdm.cpp INTERFACE_INCLUDE_DIRECTORIES)
+endif()


### PR DESCRIPTION
Here is my proposal to define a CMake target and pkg-config support. A disadvantage is a bit the name, since `tqdm` is already used for the executable, the target should be something else. I chose `tqdm.cpp`, but I think not all files can be named that way. 

Anyway, one can now have a `CMakeLists.txt` as follows:

```cmake
cmake_minimum_required(VERSION 3.1)

project(Run)

find_package(tqdm)
add_executable(${PROJECT_NAME} main.cpp)
target_link_libraries(${PROJECT_NAME} tqdm.cpp)
```

Happy to discuss!

Fixes https://github.com/tqdm/tqdm.cpp/issues/55